### PR TITLE
feat(fabricacion): dialog para elegir color previsto de base facturada

### DIFF
--- a/src/api/services/equipoFabricadoApi.ts
+++ b/src/api/services/equipoFabricadoApi.ts
@@ -172,6 +172,19 @@ export const equipoFabricadoApi = {
     return response.data;
   },
 
+  /**
+   * Setea/edita/quita el color previsto de un equipo base sin terminación (anotación en
+   * observaciones). NO asigna el color real ni consume stock: el revestimiento definitivo se
+   * aplica en la terminación. `colorId = null` quita el previsto.
+   */
+  updateColorPrevisto: async (id: number, colorId: number | null) => {
+    const response = await api.patch<EquipoFabricadoDTO>(
+      `/api/equipos-fabricados/${id}/color-previsto`,
+      { colorId },
+    );
+    return response.data;
+  },
+
   delete: async (id: number) => {
     await api.delete(`/api/equipos-fabricados/${id}`);
   },

--- a/src/components/Fabricacion/EditarColorPrevistoDialog.tsx
+++ b/src/components/Fabricacion/EditarColorPrevistoDialog.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, Box, Typography, Alert, CircularProgress, Stack,
+} from '@mui/material';
+import { Palette } from '@mui/icons-material';
+import { equipoFabricadoApi } from '../../api/services/equipoFabricadoApi';
+import type { EquipoFabricadoListDTO, EquipoFabricadoDTO } from '../../types';
+import ColorPicker from '../common/ColorPicker';
+import { useColores } from '../../context/useColores';
+
+interface EditarColorPrevistoDialogProps {
+  open: boolean;
+  equipo: EquipoFabricadoListDTO | null;
+  onClose: () => void;
+  onSuccess: (equipoActualizado: EquipoFabricadoDTO) => void;
+}
+
+/**
+ * Elige/edita el "color previsto" (revestimiento) de un equipo base ya comprometido
+ * (reservado/facturado) cuyo botón de edición estructural está bloqueado. Es solo una anotación:
+ * NO asigna el color real ni consume stock — el revestimiento definitivo se aplica en la
+ * terminación (Iniciar → Completar → Aplicar Terminación).
+ */
+const EditarColorPrevistoDialog: React.FC<EditarColorPrevistoDialogProps> = ({
+  open,
+  equipo,
+  onClose,
+  onSuccess,
+}) => {
+  const { colores } = useColores();
+  // Resolvemos el DTO completo al abrir: el list DTO puede traer id nulo y observaciones parciales.
+  const [full, setFull] = useState<EquipoFabricadoDTO | null>(null);
+  const [colorId, setColorId] = useState<number | undefined>(undefined);
+  const [loadingEquipo, setLoadingEquipo] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !equipo?.numeroHeladera) {
+      setFull(null);
+      setColorId(undefined);
+      setError(null);
+      return;
+    }
+    setLoadingEquipo(true);
+    setError(null);
+    equipoFabricadoApi.findByNumeroHeladera(equipo.numeroHeladera)
+      .then((data) => {
+        setFull(data);
+        // Preseleccionar el color previsto actual (guardado por nombre) matcheando el catálogo.
+        const previsto = data.colorPrevisto ?? equipo.colorPrevisto ?? null;
+        const matched = previsto
+          ? colores.find((c) => c.nombre.toUpperCase() === previsto.toUpperCase())
+          : undefined;
+        setColorId(matched?.id);
+      })
+      .catch(() => setError('No se pudo cargar el equipo'))
+      .finally(() => setLoadingEquipo(false));
+    // colores es estable (catálogo cacheado); no lo incluimos para no re-disparar el fetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, equipo?.numeroHeladera]);
+
+  const colorPrevistoActual = full?.colorPrevisto ?? equipo?.colorPrevisto ?? null;
+
+  const handleGuardar = async () => {
+    if (!full?.id) {
+      setError('No se pudo determinar el id del equipo');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const actualizado = await equipoFabricadoApi.updateColorPrevisto(full.id, colorId ?? null);
+      onSuccess(actualizado);
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
+      setError(msg ?? 'No se pudo guardar el color previsto');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Palette fontSize="small" />
+        Elegir revestimiento (color previsto)
+      </DialogTitle>
+      <DialogContent>
+        {loadingEquipo ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            {equipo && (
+              <Typography variant="body2" color="text.secondary">
+                Equipo <strong>{equipo.numeroHeladera}</strong> — {equipo.tipo} {equipo.modelo}
+              </Typography>
+            )}
+
+            {colorPrevistoActual && (
+              <Typography variant="body2">
+                Color previsto actual: <strong>{colorPrevistoActual}</strong>
+              </Typography>
+            )}
+
+            <ColorPicker
+              value={colorId}
+              onChange={(id) => setColorId(id)}
+              label="Color / revestimiento"
+              size="medium"
+            />
+
+            <Alert severity="info">
+              El revestimiento definitivo se aplica recién en la terminación (Iniciar → Completar →
+              Aplicar Terminación), donde se descuenta el material. Acá solo se registra el color
+              elegido para que el taller sepa qué producir.
+            </Alert>
+
+            {error && <Alert severity="error">{error}</Alert>}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ p: 2 }}>
+        <Button onClick={onClose} disabled={saving}>
+          Cancelar
+        </Button>
+        <Button
+          onClick={handleGuardar}
+          variant="contained"
+          disabled={saving || loadingEquipo}
+          startIcon={saving ? <CircularProgress size={18} /> : undefined}
+        >
+          {saving ? 'Guardando…' : 'Guardar'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default EditarColorPrevistoDialog;

--- a/src/components/Fabricacion/EquiposList.tsx
+++ b/src/components/Fabricacion/EquiposList.tsx
@@ -12,9 +12,10 @@ import type { GridColDef, GridRenderCellParams, GridColumnVisibilityModel } from
 import {
   Add, Visibility, Edit, Delete, CheckCircle, Cancel, Link, LinkOff,
   Inventory, Assignment, LocalShipping, Build, Done, TrendingUp, PlayArrow, Pending, Brush,
-  QrCode2, AssignmentTurnedIn, SwapHoriz,
+  QrCode2, AssignmentTurnedIn, SwapHoriz, Palette,
 } from '@mui/icons-material';
 import AplicarTerminacionDialog from './AplicarTerminacionDialog';
+import EditarColorPrevistoDialog from './EditarColorPrevistoDialog';
 import ReasignarEquipoDialog from './ReasignarEquipoDialog';
 import AsignarClienteDialog from './Equipos/dialogs/AsignarClienteDialog';
 import CompletarEquipoDialog from './Equipos/dialogs/CompletarEquipoDialog';
@@ -236,6 +237,13 @@ const EquiposList: React.FC = () => {
   }>({ open: false, equipo: null });
 
   const [terminacionDialog, setTerminacionDialog] = useState<{
+    open: boolean;
+    equipo: EquipoFabricadoListDTO | null;
+  }>({ open: false, equipo: null });
+
+  // Elegir color previsto (revestimiento) de una base comprometida cuyo botón Editar está
+  // bloqueado por estar reservada/facturada. Solo anota el color; no lo aplica (eso va en terminación).
+  const [colorPrevistoDialog, setColorPrevistoDialog] = useState<{
     open: boolean;
     equipo: EquipoFabricadoListDTO | null;
   }>({ open: false, equipo: null });
@@ -820,6 +828,12 @@ const EquiposList: React.FC = () => {
         const isFacturadoOrHigher = estadoAsignacion && ['FACTURADO', 'EN_TRANSITO', 'ENTREGADO'].includes(estadoAsignacion);
         const canEdit = !isReservadoOrHigher;
         const canDelete = !isReservadoOrHigher;
+        // Base sin color real y ya comprometida (reservada/facturada): el botón Editar está
+        // bloqueado, pero el revestimiento debe poder elegirse. Solo anota el color previsto.
+        // Se limita a los estados previos a la terminación: en FABRICADO_SIN_TERMINACION ya
+        // aparece "Aplicar Terminación", que es la acción correcta (aplica el color con stock).
+        const canEditColorPrevisto = isReservadoOrHigher && !params.row.color
+          && ['PENDIENTE', 'EN_PROCESO', 'PENDIENTE_CONTROL_CALIDAD'].includes(params.row.estado);
         const canAssign = params.row.estado === 'COMPLETADO' && !params.row.asignado && estadoAsignacion === 'DISPONIBLE';
         const canUnassign = params.row.asignado && !isFacturadoOrHigher;
         const canReassign = params.row.asignado && !!estadoAsignacion
@@ -857,6 +871,17 @@ const EquiposList: React.FC = () => {
                 </IconButton>
               </span>
             </Tooltip>
+            {canEditColorPrevisto && (
+              <Tooltip title="Elegir revestimiento (color previsto)">
+                <IconButton
+                  size="small"
+                  color="secondary"
+                  onClick={() => setColorPrevistoDialog({ open: true, equipo: params.row })}
+                >
+                  <Palette fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            )}
             {params.row.estado === 'PENDIENTE' && (
               <Tooltip title="Iniciar Fabricación">
                 <IconButton
@@ -1539,6 +1564,17 @@ const EquiposList: React.FC = () => {
         onClose={() => setTerminacionDialog({ open: false, equipo: null })}
         onSuccess={() => {
           setTerminacionDialog({ open: false, equipo: null });
+          refrescar();
+        }}
+      />
+
+      <EditarColorPrevistoDialog
+        open={colorPrevistoDialog.open}
+        equipo={colorPrevistoDialog.equipo}
+        onClose={() => setColorPrevistoDialog({ open: false, equipo: null })}
+        onSuccess={() => {
+          setColorPrevistoDialog({ open: false, equipo: null });
+          setSnackbar({ open: true, message: 'Color previsto actualizado', severity: 'success' });
           refrescar();
         }}
       />


### PR DESCRIPTION
Agrega el boton "Elegir revestimiento (color previsto)" en la grilla de Equipos para bases comprometidas (reservadas/facturadas) sin color real, cuyo boton Editar esta bloqueado. Es solo una anotacion: no asigna el color real ni consume stock (eso ocurre en la terminacion). Visible cuando isReservadoOrHigher && !color && estado in {PENDIENTE, EN_PROCESO, PENDIENTE_CONTROL_CALIDAD} para no solaparse con "Aplicar Terminacion".

- equipoFabricadoApi.updateColorPrevisto -> PATCH /color-previsto.
- EditarColorPrevistoDialog: ColorPicker, resuelve id via findByNumeroHeladera, preselecciona por nombre del color previsto actual.


Claude-Session: https://claude.ai/code/session_01EQV7fW8okweCorx6DhMnht